### PR TITLE
Core/Scripts: Core support for Heroic Leap

### DIFF
--- a/sql/updates/world/spell_script_name_heroic_leap.sql
+++ b/sql/updates/world/spell_script_name_heroic_leap.sql
@@ -1,0 +1,4 @@
+DELETE FROM `spell_script_names` WHERE `spell_id` IN ('6544', '178368');
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+('6544','spell_warr_heroic_leap'),
+('178368','spell_warr_heroic_leap_jump');

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -4727,7 +4727,7 @@ SpellCastResult Spell::CheckCast(bool strict)
                 return SPELL_FAILED_NOT_READY;
         }
 
-        if (!m_caster->GetSpellHistory()->IsReady(m_spellInfo))
+        if (!m_caster->GetSpellHistory()->IsReady(m_spellInfo) && !(_triggeredCastFlags & TRIGGERED_IGNORE_SPELL_AND_CATEGORY_CD))
         {
             if (m_triggeredByAuraSpell)
                 return SPELL_FAILED_DONT_REPORT;

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3256,6 +3256,9 @@ void SpellMgr::LoadSpellInfoCorrections()
                 //! HACK: This spell break quest complete for alliance and on retail not used °_O
                 const_cast<SpellEffectInfo*>(spellInfo->GetEffect(EFFECT_0))->Effect = 0;
                 break;
+            case 178368: // Heroic Leap
+                spellInfo->Speed = SPEED_CHARGE;
+                break;
             // ULDUAR SPELLS
             //
             case 62374: // Pursued (Flame Leviathan)

--- a/src/server/scripts/Spells/spell_warrior.cpp
+++ b/src/server/scripts/Spells/spell_warrior.cpp
@@ -62,7 +62,12 @@ enum WarriorSpells
     SPELL_WARRIOR_UNRELENTING_ASSAULT_TRIGGER_1     = 64849,
     SPELL_WARRIOR_UNRELENTING_ASSAULT_TRIGGER_2     = 64850,
     SPELL_WARRIOR_VIGILANCE_PROC                    = 50725,
-    SPELL_WARRIOR_VENGEANCE                         = 76691
+    SPELL_WARRIOR_VENGEANCE                         = 76691,
+    SPELL_WARRIOR_HEROIC_LEAP_DAMAGE                = 52174,
+    SPELL_WARRIOR_HEROIC_LEAP_JUMP                  = 178368,
+    SPELL_WARRIOR_GLYPH_OF_HEROIC_LEAP              = 159708,
+    SPELL_WARRIOR_GLYPH_OF_HEROIC_LEAP_BUFF         = 133278,
+    SPELL_WARRIOR_IMPROVED_HEROIC_LEAP              = 157449,
 };
 
 enum WarriorSpellIcons
@@ -948,6 +953,100 @@ class spell_warr_vigilance_trigger : public SpellScriptLoader
         }
 };
 
+// Heroic leap - 6544
+class spell_warr_heroic_leap : public SpellScriptLoader
+{
+public:
+    spell_warr_heroic_leap() : SpellScriptLoader("spell_warr_heroic_leap") { }
+
+    class spell_warr_heroic_leap_SpellScript : public SpellScript
+    {
+        PrepareSpellScript(spell_warr_heroic_leap_SpellScript);
+
+        bool Validate(SpellInfo const* /*spellInfo*/) override
+        {
+            if (!sSpellMgr->GetSpellInfo(SPELL_WARRIOR_HEROIC_LEAP_JUMP))
+                return false;
+            return true;
+        }
+
+        SpellCastResult CheckElevation()
+        {
+            if (WorldLocation const* dest = GetExplTargetDest())
+            {
+                if (dest->GetPositionZ() > GetCaster()->GetPositionZ() + 4.0f)
+                    return SPELL_FAILED_NOPATH;
+                else if (GetCaster()->HasAuraType(SPELL_AURA_MOD_ROOT))
+                    return SPELL_FAILED_ROOTED;
+
+            }
+            return SPELL_CAST_OK;
+        }
+
+        void HandleDummy(SpellEffIndex /*effIndex*/)
+        {
+            if (WorldLocation const* dest = GetExplTargetDest())
+                GetCaster()->CastSpell(dest->GetPositionX(), dest->GetPositionY(), dest->GetPositionZ(), SPELL_WARRIOR_HEROIC_LEAP_JUMP, true);
+        }
+
+        void Register() override
+        {
+            OnCheckCast += SpellCheckCastFn(spell_warr_heroic_leap_SpellScript::CheckElevation);
+            OnEffectHit += SpellEffectFn(spell_warr_heroic_leap_SpellScript::HandleDummy, EFFECT_0, SPELL_EFFECT_DUMMY);
+        }
+    };
+
+    SpellScript* GetSpellScript() const override
+    {
+        return new spell_warr_heroic_leap_SpellScript();
+    }
+};
+
+// Heroic Leap (triggered by Heroic Leap (6544)) - 178368
+class spell_warr_heroic_leap_jump : public SpellScriptLoader
+{
+public:
+    spell_warr_heroic_leap_jump() : SpellScriptLoader("spell_warr_heroic_leap_jump") { }
+
+    class spell_warr_heroic_leap_jump_SpellScript : public SpellScript
+    {
+        PrepareSpellScript(spell_warr_heroic_leap_jump_SpellScript);
+
+        bool Validate(SpellInfo const* /*spellInfo*/) override
+        {
+            if (!sSpellMgr->GetSpellInfo(SPELL_WARRIOR_HEROIC_LEAP_DAMAGE) ||
+                !sSpellMgr->GetSpellInfo(SPELL_WARRIOR_GLYPH_OF_HEROIC_LEAP) ||
+                !sSpellMgr->GetSpellInfo(SPELL_WARRIOR_GLYPH_OF_HEROIC_LEAP_BUFF) ||
+                !sSpellMgr->GetSpellInfo(SPELL_WARRIOR_IMPROVED_HEROIC_LEAP) ||
+                !sSpellMgr->GetSpellInfo(SPELL_WARRIOR_TAUNT))
+                return false;
+            return true;
+        }
+
+        void AfterJump(SpellEffIndex /*effIndex*/)
+        {
+            GetCaster()->CastSpell(GetCaster(), SPELL_WARRIOR_HEROIC_LEAP_DAMAGE, true);
+            if (Player* player = GetCaster()->ToPlayer())
+            {
+                if (player->HasAura(SPELL_WARRIOR_GLYPH_OF_HEROIC_LEAP))
+                    player->CastSpell(player, SPELL_WARRIOR_GLYPH_OF_HEROIC_LEAP_BUFF, true);
+                if (player->HasAura(SPELL_WARRIOR_IMPROVED_HEROIC_LEAP))
+                    player->GetSpellHistory()->ResetCooldown(SPELL_WARRIOR_TAUNT, true);
+            }
+        }
+
+        void Register() override
+        {
+            OnEffectHit += SpellEffectFn(spell_warr_heroic_leap_jump_SpellScript::AfterJump, EFFECT_1, SPELL_EFFECT_JUMP_DEST);
+        }
+    };
+
+    SpellScript* GetSpellScript() const override
+    {
+        return new spell_warr_heroic_leap_jump_SpellScript();
+    }
+};
+
 void AddSC_warrior_spell_scripts()
 {
     new spell_warr_bloodthirst();
@@ -972,4 +1071,6 @@ void AddSC_warrior_spell_scripts()
     new spell_warr_victorious();
     new spell_warr_vigilance();
     new spell_warr_vigilance_trigger();
+    new spell_warr_heroic_leap();
+    new spell_warr_heroic_leap_jump();
 }


### PR DESCRIPTION
- after using Heroic Leap player will now actually jump and do AOE damage after landing
- also adds support for Glyph of Heroic Leap (adds 70% movement boost after landing from heroic leap) and Improved Heroic Leap (dreanor perk, resets cooldown of Taunt after landing from heroic leap)
