### PR TITLE
Core/Unit: Correct Handling of SPELL_AURA_OVERRIDE_ACTIONBAR_SPELLS a…

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -16369,9 +16369,12 @@ SpellInfo const* Unit::GetCastSpellInfo(SpellInfo const* spellInfo) const
         swaps.insert(swaps.end(), swaps2.begin(), swaps2.end());
 
     for (AuraEffect const* auraEffect : swaps)
-        if (auraEffect->IsAffectingSpell(spellInfo))
-            if (SpellInfo const* newInfo = sSpellMgr->GetSpellInfo(auraEffect->GetAmount()))
-                return newInfo;
+    {
+        if ((!auraEffect->GetSpellEffectInfo()->SpellClassMask && auraEffect->GetMiscValue() == spellInfo->Id) ||
+            (auraEffect->GetSpellEffectInfo()->SpellClassMask && auraEffect->IsAffectingSpell(spellInfo)))
+                if (SpellInfo const* newInfo = sSpellMgr->GetSpellInfo(auraEffect->GetAmount()))
+                    return newInfo;
+    }
 
     return spellInfo;
 }


### PR DESCRIPTION
…nd SPELL_AURA_OVERRIDE_ACTIONBAR_SPELLS_2
- if aura  SPELL_AURA_OVERRIDE_ACTIONBAR_SPELLS/*_2 has a ClassMask it changes spells that fit into that classmask
- if aura  SPELL_AURA_OVERRIDE_ACTIONBAR_SPELLS/*_2 doesn't have a ClassMask it changes spells with spellId equal to miscValueA
