### PR TITLE
Core/Misc: Removed manually defined ObjectGuid copy/move constructors…

### DIFF
--- a/src/server/game/Entities/Object/ObjectGuid.h
+++ b/src/server/game/Entities/Object/ObjectGuid.h
@@ -202,11 +202,6 @@ class ObjectGuid
         static typename std::enable_if<ObjectGuidTraits<type>::MapSpecific, ObjectGuid>::type Create(uint16 mapId, uint32 entry, LowType counter) { return MapSpecific(type, 0, mapId, 0, entry, counter); }
 
         ObjectGuid() : _low(0), _high(0) { }
-        ObjectGuid(ObjectGuid const& r) : _low(r._low), _high(r._high) { }
-        ObjectGuid(ObjectGuid&& r) : _low(r._low), _high(r._high) { }
-
-        ObjectGuid& operator=(ObjectGuid const& r) { _low = r._low; _high = r._high; return *this; }
-        ObjectGuid& operator=(ObjectGuid&& r) { _low = r._low; _high = r._high; return *this; }
 
         std::vector<uint8> GetRawValue() const;
         void SetRawValue(std::vector<uint8> const& guid);


### PR DESCRIPTION
…. This will cause the compiler to automatically generate trivial constructors allowing them to be treated as simple integers
